### PR TITLE
Add ART_BINWRAP env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ The shell scripts assume the presence of the non-POSIX
 `xargs -0` and `find -print0 -maxdepth -mindepth` extensions.
 Otherwise pure POSIX.
 
+## Environment Variables
+
+Check the `README.md`s in subfolders for environment variables affecting only specific test types.
+The following affect all types:
+
+  - `ART_BINWRAP` defines a wrapper command for test binaries
+
 ## Todo
  - Crash test would ideally use a high coverage corpus,
    instead of the few randomly thrown together files used now.

--- a/crash/run-all.sh
+++ b/crash/run-all.sh
@@ -16,7 +16,7 @@ find "$tstDir" -maxdepth 1 -type f -name "*.ass" ! -name ".*" -print0 \
     sh -c '
         echo "[CRASH-TEST]: $1"
 
-        "$2" "$1" 1>/dev/null
+        $ART_BINWRAP "$2" "$1" 1>/dev/null
         ret="$?"
         if [ "$ret" -eq "0" ] ; then
             echo "OK."

--- a/crash/run-all.sh
+++ b/crash/run-all.sh
@@ -16,7 +16,7 @@ find "$tstDir" -maxdepth 1 -type f -name "*.ass" ! -name ".*" -print0 \
     sh -c '
         echo "[CRASH-TEST]: $1"
 
-        $ART_BINWRAP "$2" "$1" 1>/dev/null
+        $ART_BINWRAP "$2" -q "$1"
         ret="$?"
         if [ "$ret" -eq "0" ] ; then
             echo "OK."

--- a/regression/run-all.sh
+++ b/regression/run-all.sh
@@ -28,9 +28,9 @@ find "$tstDir" -maxdepth 1 -mindepth 1 -type d ! -name ".*" -print0 \
         fi
         echo "[TEST]: $1"
         if [ -f "$1"/scale ] ; then
-            "$2" "$1" -s "$(cat "$1"/scale)" -p "$ART_REG_TOLERANCE"
+            $ART_BINWRAP "$2" "$1" -s "$(cat "$1"/scale)" -p "$ART_REG_TOLERANCE"
         else
-            "$2" "$1" -p "$ART_REG_TOLERANCE"
+            $ART_BINWRAP "$2" "$1" -p "$ART_REG_TOLERANCE"
         fi
         ret="$?"
         if [ "$ret" -ne 0 ] ; then


### PR DESCRIPTION
The motivating usecase is MacOS’ leaks tool since ASAN’s leak detection doesn't work well (and is disabled by default). In principle this also enables testing cross-compiled binaries on the build machine with qemu-user, wine or similar and without involving full chroots (but requiring cross-compilation setups instead).