### PR TITLE
More BSDs and native ARM64

### DIFF
--- a/.github/workflows/art-vm-qemu.yml
+++ b/.github/workflows/art-vm-qemu.yml
@@ -49,6 +49,15 @@ jobs:
             # Leak detection appears to find false positives in libc and external libs
             ASAN_OPTIONS: detect_leaks=0
             ART_REG_SKIP: ''
+          - name: 'ART (openbsd64-qemu, OpenBSD-7, amd64)'
+            os_image: openbsd
+            os_version: 7.6
+            CC: 'clang'
+            confflags: ''
+            ASAN_OPTIONS: ''
+            ART_REG_SKIP: 'font_nonunicode'
+            AUTOCONF_VERSION: '2.72'
+            AUTOMAKE_VERSION: '1.16'
           # No illumos in cross-platform-actions/action yet, see
           #   https://github.com/cross-platform-actions/action/issues/20
           #- name: 'ART (illumos32-qemu, OpenIndiana, i686)'
@@ -59,6 +68,8 @@ jobs:
           #  ART_REG_SKIP: 'font_nonunicode'
     env:
       ASAN_OPTIONS: ${{ matrix.ASAN_OPTIONS }}
+      AUTOCONF_VERSION: ${{ matrix.AUTOCONF_VERSION }}
+      AUTOMAKE_VERSION: ${{ matrix.AUTOMAKE_VERSION }}
 
     steps:
       - name: Checkout Git Repos
@@ -105,7 +116,7 @@ jobs:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
           # env vars not really needed here, but must match across all steps
-          environment_variables: ASAN_OPTIONS
+          environment_variables: ASAN_OPTIONS AUTOCONF_VERSION AUTOMAKE_VERSION
           shutdown_vm: false
           sync_files: false
           run: |
@@ -124,6 +135,16 @@ jobs:
                   git nasm ca_root_nss \
                   autoconf automake libtool pkgconf \
                   freetype2 fribidi harfbuzz fontconfig png
+                ;;
+              openbsd)
+                # while OpenBSD natively uses doas,
+                # cross-platform-action only preconfigured sudo.
+                # Using system-provided: compiler, fontconfig, freetype
+                sudo pkg_add \
+                  git nasm libtool pkgconf \
+                  autoconf-"$AUTOCONF_VERSION"p0 \
+                  automake-"$AUTOMAKE_VERSION".5 \
+                  fribidi harfbuzz libunibreak png
                 ;;
               openindiana/*)
                 pfexec pkg install --no-backup-be \
@@ -148,7 +169,7 @@ jobs:
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
-          environment_variables: ASAN_OPTIONS
+          environment_variables: ASAN_OPTIONS AUTOCONF_VERSION AUTOMAKE_VERSION
           shutdown_vm: false
           sync_files: true
           run: |
@@ -163,7 +184,7 @@ jobs:
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
-          environment_variables: ASAN_OPTIONS
+          environment_variables: ASAN_OPTIONS AUTOCONF_VERSION AUTOMAKE_VERSION
           shutdown_vm: false
           sync_files: true
           run: |
@@ -178,7 +199,7 @@ jobs:
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
-          environment_variables: ASAN_OPTIONS
+          environment_variables: ASAN_OPTIONS AUTOCONF_VERSION AUTOMAKE_VERSION
           shutdown_vm: true
           sync_files: false
           run: echo 'Byebye ^^)/"'

--- a/.github/workflows/art-vm-qemu.yml
+++ b/.github/workflows/art-vm-qemu.yml
@@ -29,10 +29,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: 'ART (netbsd64-qemu, NetBSD-9, amd64)'
+          - name: 'ART (netbsd64-qemu, NetBSD-10, amd64)'
             os_image: netbsd
-            os_version: 9.3
-            CC: 'gcc -fsanitize=address -fsanitize=undefined,float-cast-overflow -fno-sanitize-recover=all'
+            os_version: 10.1
+            CC: 'gcc -fsanitize=undefined,float-cast-overflow -fno-sanitize-recover=all'
             confflags: ''
             # Leak detection appears to find false positives in libc and external libs
             ASAN_OPTIONS: detect_leaks=0
@@ -88,7 +88,7 @@ jobs:
           git log -1 --format=%H
 
       - name: Install Packages
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@v0.27.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
@@ -125,7 +125,7 @@ jobs:
             esac
 
       - name: Build libass
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@v0.27.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
@@ -140,7 +140,7 @@ jobs:
             cd ..
 
       - name: Run Tests
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@v0.27.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Shutdown VM
         if: always()
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@v0.27.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}

--- a/.github/workflows/art-vm-qemu.yml
+++ b/.github/workflows/art-vm-qemu.yml
@@ -37,6 +37,18 @@ jobs:
             # Leak detection appears to find false positives in libc and external libs
             ASAN_OPTIONS: detect_leaks=0
             ART_REG_SKIP: ''
+          - name: 'ART (freebsd64-qemu, FreeBSD-14, amd64)'
+            os_image: freebsd
+            os_version: 14.2
+            # The default FreeBSD env places the libiconv header from ports in the default include path,
+            # but doesn't put the corresponding library into the default library path.
+            # Either inlcuding the lib path (presumably done by ports) or
+            # telling libiconv’s header to pose as system iconv resolves the mismatch.
+            CC: 'clang -DLIBICONV_PLUG=1 -fsanitize=address -fsanitize=undefined,float-cast-overflow -fno-sanitize-recover=all'
+            confflags: ''
+            # Leak detection appears to find false positives in libc and external libs
+            ASAN_OPTIONS: detect_leaks=0
+            ART_REG_SKIP: ''
           # No illumos in cross-platform-actions/action yet, see
           #   https://github.com/cross-platform-actions/action/issues/20
           #- name: 'ART (illumos32-qemu, OpenIndiana, i686)'
@@ -105,6 +117,13 @@ jobs:
                     mozilla-rootcerts-openssl git nasm \
                     autoconf automake libtool-base pkg-config \
                     freetype fribidi harfbuzz fontconfig png
+                ;;
+              freebsd)
+                # Using system compiler
+                sudo pkg -o ASSUME_ALWAYS_YES=yes install \
+                  git nasm ca_root_nss \
+                  autoconf automake libtool pkgconf \
+                  freetype2 fribidi harfbuzz fontconfig png
                 ;;
               openindiana/*)
                 pfexec pkg install --no-backup-be \

--- a/.github/workflows/art.yml
+++ b/.github/workflows/art.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ${{ matrix.host_os || 'ubuntu-latest' }}
     # Run on each arch we support ASM on and furthemore
     # some additional little and big endian archs
-    # ASM:    amd64, i386  (x32 is no longer supported in GHA kernels)
+    # ASM:    amd64, i386, arm64 (x32 is no longer supported in GHA kernels)
     # Big:    s390x
-    # Little: arm64, riscv64, mips64el
+    # Little: riscv64, mips64el
     strategy:
       fail-fast: false
       matrix:
@@ -46,10 +46,11 @@ jobs:
             cflags: '-msse -msse2 -mfpmath=sse'
             sanity: sane?
             chroot-rev: 11
+          - arch: arm64
+            host_os: ubuntu-24.04-arm
+            sanity: sane?
           - arch: riscv64
             suite: sid
-            # needs at least debootstrap 1.0.128+nmu2+deb12u1 and 24.04 isn't "latest" yet
-            host_os: 'ubuntu-24.04'
             port: no
             chroot-rev: 12
           # Enable sanitisers for native build
@@ -95,7 +96,7 @@ jobs:
           outer_prefix=""
           inner_prefix=""
           case "${{ matrix.arch }}" in
-            amd64)
+            amd64|arm64)
               : ;;
             i386)
               outer_prefix="linux32"


### PR DESCRIPTION
Alternatively we could drop arm64 and amd64 from libass-tests since they are (after https://github.com/libass/libass/pull/866 ) already fully tested in the main repo